### PR TITLE
Fix PlayerControls subscription cleanup

### DIFF
--- a/src/components/game/PlayerControls.tsx
+++ b/src/components/game/PlayerControls.tsx
@@ -78,10 +78,16 @@ export default function PlayerControls() {
     };
   }, []);
 
-  const velocity = useRef<[number, number, number]>([0,0,0]);
-  const position = useRef<[number, number, number]>([0,0,0]);
-  useEffect(() => api.velocity.subscribe((v) => (velocity.current = v)), []);
-  useEffect(() => api.position.subscribe((p) => (position.current = p)), []);
+  const velocity = useRef<[number, number, number]>([0, 0, 0]);
+  const position = useRef<[number, number, number]>([0, 0, 0]);
+  useEffect(() => {
+    const unsubscribe = api.velocity.subscribe((v) => (velocity.current = v));
+    return unsubscribe;
+  }, [api.velocity]);
+  useEffect(() => {
+    const unsubscribe = api.position.subscribe((p) => (position.current = p));
+    return unsubscribe;
+  }, [api.position]);
 
   // Reuse vector instances to avoid per-frame allocations
   const forwardRef = useRef(new Vector3());


### PR DESCRIPTION
## Summary
- fix memory leak in PlayerControls by cleaning up velocity and position subscriptions

## Testing
- `npm run type-check` *(fails: Cannot find type definition file for 'next')*